### PR TITLE
Issues/3 relocate script tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,5 +42,4 @@
         }
     </script>
 </body>
-
 </html>


### PR DESCRIPTION
Closes #3 

The `<script>` tag has been relocated at the end of the `<body>` tag.